### PR TITLE
refactor(MO): convert polyfill to class impl.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ export function initialize(): void {
   let _platform = new NodeJsPlatform(_global);
   let _dom = new NodeJsDom(_global);
   let _feature = new NodeJsFeature(_global);
-  let _mutationObserver = new MutationObserver(_global, () => {}).mutationObserver;
+  let _mutationObserver = new MutationObserver(_global, () => {});
 
   initializePAL((platform, feature, dom) => {
     Object.assign(platform, _platform);

--- a/src/nodejs-mutation-observer.js
+++ b/src/nodejs-mutation-observer.js
@@ -1,600 +1,487 @@
-export class MutationObserver {
-  constructor(global, callback) {
-    let document = global.document;
-    let window = global.window;
-    window.MutationObserver = window.MutationObserver || (function(undefined) {
-      "use strict";
-      /**
-      * @param {function(Array.<MutationRecord>, MutationObserver)} listener
-      * @constructor
-      */
-      function MutationObserver(listener) {
-        /**
-        * @type {Array.<Object>}
-        * @private
-        */
-        this._watched = [];
-        /** @private */
-        this._listener = listener;
-      }
+import {jsdom} from 'jsdom';
 
-      /**
-      * Start a recursive timeout function to check all items being observed for mutations
-      * @type {MutationObserver} observer
-      * @private
-      */
-      function startMutationChecker(observer) {
-        (function check() {
-          var mutations = observer.takeRecords();
+let dom = jsdom(undefined, {}).defaultView;
+let document = dom.document;
+let counter = 1;
+let expando = 'mo_id';
 
-          if (mutations.length) { // fire away
-            // calling the listener with context is not spec but currently consistent with FF and WebKit
-            observer._listener(mutations, observer);
-          }
-          /** @private */
-          observer._timeout = setTimeout(check, MutationObserver._period);
-        })();
-      }
+let hasAttributeBug = document.createElement('i');
+hasAttributeBug.style.top = 0;
+hasAttributeBug = hasAttributeBug.attributes.style.value !== 'null';
 
-      /**
-      * Period to check for mutations (~32 times/sec)
-      * @type {number}
-      * @expose
-      */
-      MutationObserver._period = 30 /*ms+runtime*/ ;
+// GCC hack see http:// stackoverflow.com/a/23202438/1517919
+const JSCompiler_renameProperty = a => a;
 
-      /**
-      * Exposed API
-      * @expose
-      * @final
-      */
-      MutationObserver.prototype = {
-        /**
-        * see http:// dom.spec.whatwg.org/#dom-mutationobserver-observe
-        * not going to throw here but going to follow the current spec config sets
-        * @param {Node|null} $target
-        * @param {Object|null} config : MutationObserverInit configuration dictionary
-        * @expose
-        * @return undefined
-        */
-        observe: function($target, config) {
-          /**
-          * Using slightly different names so closure can go ham
-          * @type {!Object} : A custom mutation config
-          */
-          var settings = {
-            attr: !! (config.attributes || config.attributeFilter || config.attributeOldValue),
+const getAttributeWithStyleHack = (el, attr) => {
+  // As with getAttributeSimple there is a potential warning for custom attribtues in IE7.
+  return attr.name !== 'style' ? attr.value : el.style.cssText;
+};
 
-            // some browsers enforce that subtree must be set with childList, attributes or characterData.
-            // We don't care as spec doesn't specify this rule.
-            kids: !! config.childList,
-            descendents: !! config.subtree,
-            charData: !! (config.characterData || config.characterDataOldValue)
-          };
+const getAttributeSimple = (el, attr) => attr.value;
 
-          var watched = this._watched;
+const getAttributeValue = hasAttributeBug ? getAttributeSimple : getAttributeWithStyleHack;
 
-          // remove already observed target element from pool
-          for (var i = 0; i < watched.length; i++) {
-            if (watched[i].tar === $target) watched.splice(i, 1);
-          }
-
-          if (config.attributeFilter) {
-            /**
-            * converts to a {key: true} dict for faster lookup
-            * @type {Object.<String,Boolean>}
-            */
-            settings.afilter = reduce(config.attributeFilter, function(a, b) {
-              a[b] = true;
-              return a;
-            }, {});
-          }
-
-          watched.push({
-            tar: $target,
-            fn: createMutationSearcher($target, settings)
-          });
-
-          // reconnect if not connected
-          if (!this._timeout) {
-            startMutationChecker(this);
-          }
-        },
-
-        /**
-        * Finds mutations since last check and empties the "record queue" i.e. mutations will only be found once
-        * @expose
-        * @return {Array.<MutationRecord>}
-        */
-        takeRecords: function() {
-          var mutations = [];
-          var watched = this._watched;
-
-          for (var i = 0; i < watched.length; i++) {
-            watched[i].fn(mutations);
-          }
-
-          return mutations;
-        },
-
-        /**
-        * @expose
-        * @return undefined
-        */
-        disconnect: function() {
-          this._watched = []; // clear the stuff being observed
-          clearTimeout(this._timeout); // ready for garbage collection
-          /** @private */
-          this._timeout = null;
-        }
+export class Util {
+  static clone($target, config) {
+    let recurse = true; // set true so childList we'll always check the first level
+    return (function copy($target) {
+      let elestruct = {
+        /** @type {Node} */
+        node: $target
       };
 
-      /**
-      * Simple MutationRecord pseudoclass. No longer exposing as its not fully compliant
-      * @param {Object} data
-      * @return {Object} a MutationRecord
-      */
-      function MutationRecord(data) {
-        var settings = { // technically these should be on proto so hasOwnProperty will return false for non explicitly props
-          type: null,
-          target: null,
-          addedNodes: [],
-          removedNodes: [],
-          previousSibling: null,
-          nextSibling: null,
-          attributeName: null,
-          attributeNamespace: null,
-          oldValue: null
-        };
-        for (var prop in data) {
-          if (has(settings, prop) && data[prop] !== undefined) settings[prop] = data[prop];
-        }
-        return settings;
-      }
-
-      /**
-      * Creates a func to find all the mutations
-      *
-      * @param {Node} $target
-      * @param {!Object} config : A custom mutation config
-      */
-      function createMutationSearcher($target, config) {
-        /** type {Elestuct} */
-        var $oldstate = clone($target, config); // create the cloned datastructure
-
-        /**
-        * consumes array of mutations we can push to
-        *
-        * @param {Array.<MutationRecord>} mutations
-        */
-        return function(mutations) {
-          var olen = mutations.length, dirty;
-
-          // Alright we check base level changes in attributes... easy
-          if (config.attr && $oldstate.attr) {
-            findAttributeMutations(mutations, $target, $oldstate.attr, config.afilter);
-          }
-
-          // check childlist or subtree for mutations
-          if (config.kids || config.descendents) {
-            dirty = searchSubtree(mutations, $target, $oldstate, config);
-          }
-
-          // reclone data structure if theres changes
-          if (dirty || mutations.length !== olen) {
-            /** type {Elestuct} */
-            $oldstate = clone($target, config);
-          }
-        };
-      }
-
-      /* attributes + attributeFilter helpers */
-
-      // Check if the environment has the attribute bug (#4) which cause
-      // element.attributes.style to always be null.
-      var hasAttributeBug = document.createElement("i");
-      hasAttributeBug.style.top = 0;
-      hasAttributeBug = hasAttributeBug.attributes.style.value != "null";
-
-      /**
-      * Gets an attribute value in an environment without attribute bug
-      *
-      * @param {Node} el
-      * @param {Attr} attr
-      * @return {String} an attribute value
-      */
-      function getAttributeSimple(el, attr) {
-        // There is a potential for a warning to occur here if the attribute is a
-        // custom attribute in IE<9 with a custom .toString() method. This is
-        // just a warning and doesn't affect execution (see #21)
-        return attr.value;
-      }
-
-      /**
-      * Gets an attribute value with special hack for style attribute (see #4)
-      *
-      * @param {Node} el
-      * @param {Attr} attr
-      * @return {String} an attribute value
-      */
-      function getAttributeWithStyleHack(el, attr) {
-        // As with getAttributeSimple there is a potential warning for custom attribtues in IE7.
-        return attr.name !== "style" ? attr.value : el.style.cssText;
-      }
-
-      var getAttributeValue = hasAttributeBug ? getAttributeSimple : getAttributeWithStyleHack;
-
-      /**
-      * fast helper to check to see if attributes object of an element has changed
-      * doesnt handle the textnode case
-      *
-      * @param {Array.<MutationRecord>} mutations
-      * @param {Node} $target
-      * @param {Object.<string, string>} $oldstate : Custom attribute clone data structure from clone
-      * @param {Object} filter
-      */
-      function findAttributeMutations(mutations, $target, $oldstate, filter) {
-        var checked = {};
-        var attributes = $target.attributes;
-        var attr;
-        var name;
-        var i = attributes.length;
-        while (i--) {
-          attr = attributes[i];
-          name = attr.name;
-          if (!filter || has(filter, name)) {
-            if (getAttributeValue($target, attr) !== $oldstate[name]) {
-              // The pushing is redundant but gzips very nicely
-              mutations.push(MutationRecord({
-                type: "attributes",
-                target: $target,
-                attributeName: name,
-                oldValue: $oldstate[name],
-                attributeNamespace: attr.namespaceURI // in ie<8 it incorrectly will return undefined
-              }));
+      // Store current character data of target text or comment node if the config requests
+      // those properties to be observed.
+      if (config.charData && ($target.nodeType === 3 || $target.nodeType === 8)) {
+        elestruct.charData = $target.nodeValue;
+      } else {
+        // Add attr only if subtree is specified or top level and avoid if
+        // attributes is a document object (#13).
+        if (config.attr && recurse && $target.nodeType === 1) {
+          /**
+          * clone live attribute list to an object structure {name: val}
+          * @type {Object.<string, string>}
+          */
+          elestruct.attr = Util.reduce($target.attributes, (memo, attr) => {
+            if (!config.afilter || config.afilter[attr.name]) {
+              memo[attr.name] = getAttributeValue($target, attr);
             }
-            checked[name] = true;
-          }
+            return memo;
+          }, {});
         }
-        for (name in $oldstate) {
-          if (!(checked[name])) {
-            mutations.push(MutationRecord({
-              target: $target,
-              type: "attributes",
-              attributeName: name,
-              oldValue: $oldstate[name]
+
+        // whether we should iterate the children of $target node
+        if (recurse && ((config.kids || config.charData) || (config.attr && config.descendents)) ) {
+          /** @type {Array.<!Object>} : Array of custom clone */
+          elestruct.kids = Util.map($target.childNodes, copy);
+        }
+
+        recurse = config.descendents;
+      }
+      return elestruct;
+    })($target);
+  }
+
+  /**
+  * indexOf an element in a collection of custom nodes
+  *
+  * @param {NodeList} set
+  * @param {!Object} $node : A custom cloned nodeg333
+  * @param {number} idx : index to start the loop
+  * @return {number}
+  */
+  static indexOfCustomNode(set, $node, idx) {
+    return this.indexOf(set, $node, idx, JSCompiler_renameProperty('node'));
+  }
+
+  /**
+  * Attempt to uniquely id an element for hashing. We could optimize this for legacy browsers but it hopefully wont be called enough to be a concern
+  *
+  * @param {Node} $ele
+  * @return {(string|number)}
+  */
+  static getElementId($ele) {
+    try {
+      return $ele.id || ($ele[expando] = $ele[expando] || counter++);
+    } catch (e) { // ie <8 will throw if you set an unknown property on a text node
+      try {
+        return $ele.nodeValue; // naive
+      } catch (shitie) { // when text node is removed: https://gist.github.com/megawac/8355978 :(
+        return counter++;
+      }
+    }
+  }
+
+  /**
+  * **map** Apply a mapping function to each item of a set
+  * @param {Array|NodeList} set
+  * @param {Function} iterator
+  */
+  static map(set, iterator) {
+    let results = [];
+    for (let index = 0; index < set.length; index++) {
+      results[index] = iterator(set[index], index, set);
+    }
+    return results;
+  }
+
+  /**
+  * **Reduce** builds up a single result from a list of values
+  * @param {Array|NodeList|NamedNodeMap} set
+  * @param {Function} iterator
+  * @param {*} [memo] Initial value of the memo.
+  */
+  static reduce(set, iterator, memo) {
+    for (let index = 0; index < set.length; index++) {
+      memo = iterator(memo, set[index], index, set);
+    }
+    return memo;
+  }
+
+  /**
+  * **indexOf** find index of item in collection.
+  * @param {Array|NodeList} set
+  * @param {Object} item
+  * @param {number} idx
+  * @param {string} [prop] Property on set item to compare to item
+  */
+  static indexOf(set, item, idx, prop) {
+    for (/*idx = ~~idx*/; idx < set.length; idx++) {// start idx is always given as this is internal
+      if ((prop ? set[idx][prop] : set[idx]) === item) return idx;
+    }
+    return -1;
+  }
+
+  /**
+  * @param {Object} obj
+  * @param {(string|number)} prop
+  * @return {boolean}
+  */
+  static has(obj, prop) {
+    return obj[prop] !== undefined; // will be nicely inlined by gcc
+  }
+}
+
+export class MutationObserver {
+  constructor(listener) {
+    this._watched = [];
+    this._listener = listener;
+    this._period = 30;
+  }
+
+  observe($target, config) {
+    let settings = {
+      attr: !! (config.attributes || config.attributeFilter || config.attributeOldValue),
+
+      // some browsers enforce that subtree must be set with childList, attributes or characterData.
+      // We don't care as spec doesn't specify this rule.
+      kids: !! config.childList,
+      descendents: !! config.subtree,
+      charData: !! (config.characterData || config.characterDataOldValue)
+    };
+
+    let watched = this._watched;
+
+    // remove already observed target element from pool
+    for (let i = 0; i < watched.length; i++) {
+      if (watched[i].tar === $target) watched.splice(i, 1);
+    }
+
+    if (config.attributeFilter) {
+      /**
+      * converts to a {key: true} dict for faster lookup
+      * @type {Object.<String,Boolean>}
+      */
+      settings.afilter = Util.reduce(config.attributeFilter, (a, b) => {
+        a[b] = true;
+        return a;
+      }, {});
+    }
+
+    watched.push({
+      tar: $target,
+      fn: this._createMutationSearcher($target, settings)
+    });
+
+    // reconnect if not connected
+    if (!this._timeout) {
+      this._startMutationChecker(this);
+    }
+  }
+
+  takeRecords() {
+    let mutations = [];
+    let watched = this._watched;
+
+    for (let i = 0; i < watched.length; i++) {
+      watched[i].fn(mutations);
+    }
+
+    return mutations;
+  }
+
+  disconnect() {
+    this._watched = []; // clear the stuff being observed
+    clearTimeout(this._timeout); // ready for garbage collection
+    /** @private */
+    this._timeout = null;
+  }
+
+  _createMutationSearcher($target, config) {
+    /** type {Elestuct} */
+    let $oldstate = Util.clone($target, config); // create the cloned datastructure
+
+    /**
+    * consumes array of mutations we can push to
+    *
+    * @param {Array.<MutationRecord>} mutations
+    */
+    return (mutations) => {
+      let olen = mutations.length;
+      let dirty;
+
+      // Alright we check base level changes in attributes... easy
+      if (config.attr && $oldstate.attr) {
+        this._findAttributeMutations(mutations, $target, $oldstate.attr, config.afilter);
+      }
+
+      // check childlist or subtree for mutations
+      if (config.kids || config.descendents) {
+        dirty = this._searchSubtree(mutations, $target, $oldstate, config);
+      }
+
+      // reclone data structure if theres changes
+      if (dirty || mutations.length !== olen) {
+        /** type {Elestuct} */
+        $oldstate = Util.clone($target, config);
+      }
+    };
+  }
+
+  _startMutationChecker(observer) {
+    const check = () => {
+      let mutations = observer.takeRecords();
+
+      if (mutations.length) { // fire away
+        // calling the listener with context is not spec but currently consistent with FF and WebKit
+        observer._listener(mutations, observer);
+      }
+      /** @private */
+      observer._timeout = setTimeout(check, this._period);
+    };
+    check();
+  }
+
+  _searchSubtree(mutations, $target, $oldstate, config) {
+    // Track if the tree is dirty and has to be recomputed (#14).
+    let dirty;
+    /*
+    * Helper to identify node rearrangment and stuff...
+    * There is no gaurentee that the same node will be identified for both added and removed nodes
+    * if the positions have been shuffled.
+    * conflicts array will be emptied by end of operation
+    */
+    const _resolveConflicts = (conflicts, node, $kids, $oldkids, numAddedNodes) => {
+      // the distance between the first conflicting node and the last
+      let distance = conflicts.length - 1;
+      // prevents same conflict being resolved twice consider when two nodes switch places.
+      // only one should be given a mutation event (note -~ is used as a math.ceil shorthand)
+      let counter = -~((distance - numAddedNodes) / 2);
+      let $cur;
+      let oldstruct;
+      let conflict;
+      while ((conflict = conflicts.pop())) {
+        $cur = $kids[conflict.i];
+        oldstruct = $oldkids[conflict.j];
+
+        // attempt to determine if there was node rearrangement... won't gaurentee all matches
+        // also handles case where added/removed nodes cause nodes to be identified as conflicts
+        if (config.kids && counter && Math.abs(conflict.i - conflict.j) >= distance) {
+          mutations.push(new MutationRecord({
+            type: 'childList',
+            target: node,
+            addedNodes: [$cur],
+            removedNodes: [$cur],
+            // haha don't rely on this please
+            nextSibling: $cur.nextSibling,
+            previousSibling: $cur.previousSibling
+          }));
+          counter--; // found conflict
+        }
+
+        // Alright we found the resorted nodes now check for other types of mutations
+        if (config.attr && oldstruct.attr) this._findAttributeMutations(mutations, $cur, oldstruct.attr, config.afilter);
+        if (config.charData && $cur.nodeType === 3 && $cur.nodeValue !== oldstruct.charData) {
+          mutations.push(new MutationRecord({
+            type: 'characterData',
+            target: $cur
+          }));
+        }
+        // now look @ subtree
+        if (config.descendents) _findMutations($cur, oldstruct);
+      }
+    };
+
+    /**
+    * Main worker. Finds and adds mutations if there are any
+    * @param {Node} node
+    * @param {!Object} old : A cloned data structure using internal clone
+    */
+    const _findMutations = (node, old) => {
+      let $kids = node.childNodes;
+      let $oldkids = old.kids;
+      let klen = $kids.length;
+      // $oldkids will be undefined for text and comment nodes
+      let olen = $oldkids ? $oldkids.length : 0;
+      // if (!olen && !klen) return; // both empty; clearly no changes
+
+      // we delay the intialization of these for marginal performance in the expected case (actually quite signficant on large subtrees when these would be otherwise unused)
+      // map of checked element of ids to prevent registering the same conflict twice
+      let map;
+      // array of potential conflicts (ie nodes that may have been re arranged)
+      let conflicts;
+      let id; // element id from getElementId helper
+      let idx; // index of a moved or inserted element
+
+      let oldstruct;
+      // current and old nodes
+      let $cur;
+      let $old;
+      // track the number of added nodes so we can resolve conflicts more accurately
+      let numAddedNodes = 0;
+
+      // iterate over both old and current child nodes at the same time
+      let i = 0;
+      let j = 0;
+      // while there is still anything left in $kids or $oldkids (same as i < $kids.length || j < $oldkids.length;)
+      while ( i < klen || j < olen ) {
+        // current and old nodes at the indexs
+        $cur = $kids[i];
+        oldstruct = $oldkids[j];
+        $old = oldstruct && oldstruct.node;
+
+        if ($cur === $old) { // expected case - optimized for this case
+          // check attributes as specified by config
+          if (config.attr && oldstruct.attr) {/* oldstruct.attr instead of textnode check */
+            this._findAttributeMutations(mutations, $cur, oldstruct.attr, config.afilter);
+          }
+          // check character data if node is a comment or textNode and it's being observed
+          if (config.charData && oldstruct.charData !== undefined && $cur.nodeValue !== oldstruct.charData) {
+            mutations.push(new MutationRecord({
+              type: 'characterData',
+              target: $cur
             }));
           }
-        }
-      }
 
-      /**
-      * searchSubtree: array of mutations so far, element, element clone, bool
-      * synchronous dfs comparision of two nodes
-      * This function is applied to any observed element with childList or subtree specified
-      * Sorry this is kind of confusing as shit, tried to comment it a bit...
-      * codereview.stackexchange.com/questions/38351 discussion of an earlier version of this func
-      *
-      * @param {Array} mutations
-      * @param {Node} $target
-      * @param {!Object} $oldstate : A custom cloned node from clone()
-      * @param {!Object} config : A custom mutation config
-      */
-      function searchSubtree(mutations, $target, $oldstate, config) {
-        // Track if the tree is dirty and has to be recomputed (#14).
-        var dirty;
-        /*
-        * Helper to identify node rearrangment and stuff...
-        * There is no gaurentee that the same node will be identified for both added and removed nodes
-        * if the positions have been shuffled.
-        * conflicts array will be emptied by end of operation
-        */
-        function resolveConflicts(conflicts, node, $kids, $oldkids, numAddedNodes) {
-          // the distance between the first conflicting node and the last
-          var distance = conflicts.length - 1;
-          // prevents same conflict being resolved twice consider when two nodes switch places.
-          // only one should be given a mutation event (note -~ is used as a math.ceil shorthand)
-          var counter = -~((distance - numAddedNodes) / 2);
-          var $cur;
-          var oldstruct;
-          var conflict;
-          while ((conflict = conflicts.pop())) {
-            $cur = $kids[conflict.i];
-            oldstruct = $oldkids[conflict.j];
+          // resolve conflicts; it will be undefined if there are no conflicts - otherwise an array
+          if (conflicts) _resolveConflicts(conflicts, node, $kids, $oldkids, numAddedNodes);
 
-            // attempt to determine if there was node rearrangement... won't gaurentee all matches
-            // also handles case where added/removed nodes cause nodes to be identified as conflicts
-            if (config.kids && counter && Math.abs(conflict.i - conflict.j) >= distance) {
-              mutations.push(MutationRecord({
-                type: "childList",
-                target: node,
-                addedNodes: [$cur],
-                removedNodes: [$cur],
-                // haha don't rely on this please
-                nextSibling: $cur.nextSibling,
-                previousSibling: $cur.previousSibling
-              }));
-              counter--; // found conflict
-            }
+          // recurse on next level of children. Avoids the recursive call when there are no children left to iterate
+          if (config.descendents && ($cur.childNodes.length || oldstruct.kids && oldstruct.kids.length)) _findMutations($cur, oldstruct);
 
-            // Alright we found the resorted nodes now check for other types of mutations
-            if (config.attr && oldstruct.attr) findAttributeMutations(mutations, $cur, oldstruct.attr, config.afilter);
-            if (config.charData && $cur.nodeType === 3 && $cur.nodeValue !== oldstruct.charData) {
-              mutations.push(MutationRecord({
-                type: "characterData",
-                target: $cur
-              }));
-            }
-            // now look @ subtree
-            if (config.descendents) findMutations($cur, oldstruct);
+          i++;
+          j++;
+        } else { // (uncommon case) lookahead until they are the same again or the end of children
+          dirty = true;
+          if (!map) { // delayed initalization (big perf benefit)
+            map = {};
+            conflicts = [];
           }
-        }
-
-        /**
-        * Main worker. Finds and adds mutations if there are any
-        * @param {Node} node
-        * @param {!Object} old : A cloned data structure using internal clone
-        */
-        function findMutations(node, old) {
-          var $kids = node.childNodes;
-          var $oldkids = old.kids;
-          var klen = $kids.length;
-          // $oldkids will be undefined for text and comment nodes
-          var olen = $oldkids ? $oldkids.length : 0;
-          // if (!olen && !klen) return; // both empty; clearly no changes
-
-          // we delay the intialization of these for marginal performance in the expected case (actually quite signficant on large subtrees when these would be otherwise unused)
-          // map of checked element of ids to prevent registering the same conflict twice
-          var map;
-          // array of potential conflicts (ie nodes that may have been re arranged)
-          var conflicts;
-          var id; // element id from getElementId helper
-          var idx; // index of a moved or inserted element
-
-          var oldstruct;
-          // current and old nodes
-          var $cur;
-          var $old;
-          // track the number of added nodes so we can resolve conflicts more accurately
-          var numAddedNodes = 0;
-
-          // iterate over both old and current child nodes at the same time
-          var i = 0, j = 0;
-          // while there is still anything left in $kids or $oldkids (same as i < $kids.length || j < $oldkids.length;)
-          while( i < klen || j < olen ) {
-            // current and old nodes at the indexs
-            $cur = $kids[i];
-            oldstruct = $oldkids[j];
-            $old = oldstruct && oldstruct.node;
-
-            if ($cur === $old) { // expected case - optimized for this case
-              // check attributes as specified by config
-              if (config.attr && oldstruct.attr) /* oldstruct.attr instead of textnode check */findAttributeMutations(mutations, $cur, oldstruct.attr, config.afilter);
-              // check character data if node is a comment or textNode and it's being observed
-              if (config.charData && oldstruct.charData !== undefined && $cur.nodeValue !== oldstruct.charData) {
-                mutations.push(MutationRecord({
-                  type: "characterData",
-                  target: $cur
-                }));
-              }
-
-              // resolve conflicts; it will be undefined if there are no conflicts - otherwise an array
-              if (conflicts) resolveConflicts(conflicts, node, $kids, $oldkids, numAddedNodes);
-
-              // recurse on next level of children. Avoids the recursive call when there are no children left to iterate
-              if (config.descendents && ($cur.childNodes.length || oldstruct.kids && oldstruct.kids.length)) findMutations($cur, oldstruct);
-
-              i++;
-              j++;
-            } else { // (uncommon case) lookahead until they are the same again or the end of children
-              dirty = true;
-              if (!map) { // delayed initalization (big perf benefit)
-                map = {};
-                conflicts = [];
-              }
-              if ($cur) {
-                // check id is in the location map otherwise do a indexOf search
-                if (!(map[id = getElementId($cur)])) { // to prevent double checking
-                  // mark id as found
-                  map[id] = true;
-                  // custom indexOf using comparitor checking oldkids[i].node === $cur
-                  if ((idx = indexOfCustomNode($oldkids, $cur, j)) === -1) {
-                    if (config.kids) {
-                      mutations.push(MutationRecord({
-                        type: "childList",
-                        target: node,
-                        addedNodes: [$cur], // $cur is a new node
-                        nextSibling: $cur.nextSibling,
-                        previousSibling: $cur.previousSibling
-                      }));
-                      numAddedNodes++;
-                    }
-                  } else {
-                    conflicts.push({ // add conflict
-                      i: i,
-                      j: idx
-                    });
-                  }
+          if ($cur) {
+            // check id is in the location map otherwise do a indexOf search
+            if (!(map[id = Util.getElementId($cur)])) { // to prevent double checking
+              // mark id as found
+              map[id] = true;
+              // custom indexOf using comparitor checking oldkids[i].node === $cur
+              if ((idx = Util.indexOfCustomNode($oldkids, $cur, j)) === -1) {
+                if (config.kids) {
+                  mutations.push(new MutationRecord({
+                    type: 'childList',
+                    target: node,
+                    addedNodes: [$cur], // $cur is a new node
+                    nextSibling: $cur.nextSibling,
+                    previousSibling: $cur.previousSibling
+                  }));
+                  numAddedNodes++;
                 }
-                i++;
+              } else {
+                conflicts.push({ // add conflict
+                  i: i,
+                  j: idx
+                });
               }
+            }
+            i++;
+          }
 
-              if ($old &&
-                // special case: the changes may have been resolved: i and j appear congurent so we can continue using the expected case
-                $old !== $kids[i]
-              ) {
-                if (!(map[id = getElementId($old)])) {
-                  map[id] = true;
-                  if ((idx = indexOf($kids, $old, i)) === -1) {
-                    if (config.kids) {
-                      mutations.push(MutationRecord({
-                        type: "childList",
-                        target: old.node,
-                        removedNodes: [$old],
-                        nextSibling: $oldkids[j + 1], // praise no indexoutofbounds exception
-                        previousSibling: $oldkids[j - 1]
-                      }));
-                      numAddedNodes--;
-                    }
-                  } else {
-                    conflicts.push({
-                      i: idx,
-                      j: j
-                    });
-                  }
+          if ($old &&
+            // special case: the changes may have been resolved: i and j appear congurent so we can continue using the expected case
+            $old !== $kids[i]
+          ) {
+            if (!(map[id = Util.getElementId($old)])) {
+              map[id] = true;
+              if ((idx = Util.indexOf($kids, $old, i)) === -1) {
+                if (config.kids) {
+                  mutations.push(new MutationRecord({
+                    type: 'childList',
+                    target: old.node,
+                    removedNodes: [$old],
+                    nextSibling: $oldkids[j + 1], // praise no indexoutofbounds exception
+                    previousSibling: $oldkids[j - 1]
+                  }));
+                  numAddedNodes--;
                 }
-                j++;
+              } else {
+                conflicts.push({
+                  i: idx,
+                  j: j
+                });
               }
-            }// end uncommon case
-          }// end loop
-
-          // resolve any remaining conflicts
-          if (conflicts) resolveConflicts(conflicts, node, $kids, $oldkids, numAddedNodes);
-        }
-        findMutations($target, $oldstate);
-        return dirty;
-      }
-
-      /**
-      * Utility
-      * Cones a element into a custom data structure designed for comparision. https://gist.github.com/megawac/8201012
-      *
-      * @param {Node} $target
-      * @param {!Object} config : A custom mutation config
-      * @return {!Object} : Cloned data structure
-      */
-      function clone($target, config) {
-        var recurse = true; // set true so childList we'll always check the first level
-        return (function copy($target) {
-          var elestruct = {
-            /** @type {Node} */
-            node: $target
-          };
-
-          // Store current character data of target text or comment node if the config requests
-          // those properties to be observed.
-          if (config.charData && ($target.nodeType === 3 || $target.nodeType === 8)) {
-            elestruct.charData = $target.nodeValue;
-          }
-          // its either a element, comment, doc frag or document node
-          else {
-            // Add attr only if subtree is specified or top level and avoid if
-            // attributes is a document object (#13).
-            if (config.attr && recurse && $target.nodeType === 1) {
-              /**
-              * clone live attribute list to an object structure {name: val}
-              * @type {Object.<string, string>}
-              */
-              elestruct.attr = reduce($target.attributes, function(memo, attr) {
-                if (!config.afilter || config.afilter[attr.name]) {
-                  memo[attr.name] = getAttributeValue($target, attr);
-                }
-                return memo;
-              }, {});
             }
-
-            // whether we should iterate the children of $target node
-            if (recurse && ((config.kids || config.charData) || (config.attr && config.descendents)) ) {
-              /** @type {Array.<!Object>} : Array of custom clone */
-              elestruct.kids = map($target.childNodes, copy);
-            }
-
-            recurse = config.descendents;
+            j++;
           }
-          return elestruct;
-        })($target);
-      }
+        }// end uncommon case
+      }// end loop
 
-      /**
-      * indexOf an element in a collection of custom nodes
-      *
-      * @param {NodeList} set
-      * @param {!Object} $node : A custom cloned node
-      * @param {number} idx : index to start the loop
-      * @return {number}
-      */
-      function indexOfCustomNode(set, $node, idx) {
-        return indexOf(set, $node, idx, JSCompiler_renameProperty("node"));
-      }
+      // resolve any remaining conflicts
+      if (conflicts) _resolveConflicts(conflicts, node, $kids, $oldkids, numAddedNodes);
+    };
+    _findMutations($target, $oldstate);
+    return dirty;
+  }
 
-      // using a non id (eg outerHTML or nodeValue) is extremely naive and will run into issues with nodes that may appear the same like <li></li>
-      var counter = 1; // don't use 0 as id (falsy)
-      /** @const */
-      var expando = "mo_id";
-
-      /**
-      * Attempt to uniquely id an element for hashing. We could optimize this for legacy browsers but it hopefully wont be called enough to be a concern
-      *
-      * @param {Node} $ele
-      * @return {(string|number)}
-      */
-      function getElementId($ele) {
-        try {
-          return $ele.id || ($ele[expando] = $ele[expando] || counter++);
-        } catch (o_O) { // ie <8 will throw if you set an unknown property on a text node
-          try {
-            return $ele.nodeValue; // naive
-          } catch (shitie) { // when text node is removed: https://gist.github.com/megawac/8355978 :(
-            return counter++;
-          }
+  _findAttributeMutations(mutations, $target, $oldstate, filter) {
+    let checked = {};
+    let attributes = $target.attributes;
+    let attr;
+    let name;
+    let i = attributes.length;
+    while (i--) {
+      attr = attributes[i];
+      name = attr.name;
+      if (!filter || has(filter, name)) {
+        if (getAttributeValue($target, attr) !== $oldstate[name]) {
+          // The pushing is redundant but gzips very nicely
+          mutations.push(new MutationRecord({
+            type: 'attributes',
+            target: $target,
+            attributeName: name,
+            oldValue: $oldstate[name],
+            attributeNamespace: attr.namespaceURI // in ie<8 it incorrectly will return undefined
+          }));
         }
+        checked[name] = true;
       }
-
-      /**
-      * **map** Apply a mapping function to each item of a set
-      * @param {Array|NodeList} set
-      * @param {Function} iterator
-      */
-      function map(set, iterator) {
-        var results = [];
-        for (var index = 0; index < set.length; index++) {
-          results[index] = iterator(set[index], index, set);
-        }
-        return results;
+    }
+    for (name in $oldstate) {
+      if (!(checked[name])) {
+        mutations.push(new MutationRecord({
+          target: $target,
+          type: 'attributes',
+          attributeName: name,
+          oldValue: $oldstate[name]
+        }));
       }
+    }
+  }
+}
 
-      /**
-      * **Reduce** builds up a single result from a list of values
-      * @param {Array|NodeList|NamedNodeMap} set
-      * @param {Function} iterator
-      * @param {*} [memo] Initial value of the memo.
-      */
-      function reduce(set, iterator, memo) {
-        for (var index = 0; index < set.length; index++) {
-          memo = iterator(memo, set[index], index, set);
-        }
-        return memo;
-      }
-
-      /**
-      * **indexOf** find index of item in collection.
-      * @param {Array|NodeList} set
-      * @param {Object} item
-      * @param {number} idx
-      * @param {string} [prop] Property on set item to compare to item
-      */
-      function indexOf(set, item, idx, prop) {
-        for (/*idx = ~~idx*/; idx < set.length; idx++) {// start idx is always given as this is internal
-          if ((prop ? set[idx][prop] : set[idx]) === item) return idx;
-        }
-        return -1;
-      }
-
-      /**
-      * @param {Object} obj
-      * @param {(string|number)} prop
-      * @return {boolean}
-      */
-      function has(obj, prop) {
-        return obj[prop] !== undefined; // will be nicely inlined by gcc
-      }
-
-      // GCC hack see http:// stackoverflow.com/a/23202438/1517919
-      const JSCompiler_renameProperty = a => a;
-
-      return MutationObserver;
-    })(void 0);
-
-    this.mutationObserver = new window.MutationObserver(callback);
+export class MutationRecord {
+  constructor(data) {
+    let settings = { // technically these should be on proto so hasOwnProperty will return false for non explicitly props
+      type: null,
+      target: null,
+      addedNodes: [],
+      removedNodes: [],
+      previousSibling: null,
+      nextSibling: null,
+      attributeName: null,
+      attributeNamespace: null,
+      oldValue: null
+    };
+    for (let prop in data) {
+      if (Util.has(settings, prop) && data[prop] !== undefined) settings[prop] = data[prop];
+    }
+    return settings;
   }
 }

--- a/test/nodejs-mutation-source.spec.js
+++ b/test/nodejs-mutation-source.spec.js
@@ -11,7 +11,7 @@ describe("Mutation Observer", () => {
   beforeEach(() => {
     dom = jsdom(undefined, {}).defaultView;
     document = dom.document;
-    observer = new MutationObserver(dom, noop).mutationObserver;
+    observer = new MutationObserver(dom, noop);
   });
 
   afterEach(() => {
@@ -129,7 +129,6 @@ describe("Mutation Observer", () => {
 
   xit('should detect changes for a single text node', () => {
     const textNode = document.createTextNode(`I'm a text node`);
-    console.dir(textNode);
 
     observer.observe(textNode, {
       attributes: true,


### PR DESCRIPTION
The purpose of this commit is to split the MO polyfill into separate classes introduced in #5.

@MeirionHughes Do you think this can be refactored any further?

@martingust - Similarly to the last [PR](https://github.com/aurelia/pal-nodejs/pull/5), this should be split into separate files - although, gulp doesn't recognize ANY tests when I added a new file to src/. I tried to figure out this issue - but couldn't find a solution.