### PR TITLE
chore(jsdom): peerDependency for jsdom

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "type": "git",
     "url": "http://github.com/aurelia/pal-nodejs"
   },
+  "peerDependencies": {
+    "jsdom": "^11.1.0"
+  },
   "dependencies": {
     "aurelia-pal": "^1.1.0",
     "jsdom": "^11.1.0"

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "url": "http://github.com/aurelia/pal-nodejs"
   },
   "peerDependencies": {
-    "jsdom": "^11.1.0"
+    "jsdom": "~11.5.1"
   },
   "dependencies": {
     "aurelia-pal": "^1.1.0",
-    "jsdom": "^11.1.0"
+    "jsdom": "~11.5.1"
   },
   "devDependencies": {
     "@types/jasmine": "^2.2.34",


### PR DESCRIPTION
a recent breaking change update of JSDOM elimnated the private window._core API so this is a workaround for the time being

Related issue https://github.com/aurelia/pal-nodejs/issues/24