### PR TITLE
fix(nodejs-pal-builder) MutationObserver not handling changes to CharacterData.data

### DIFF
--- a/spec/mutation-observer.spec.ts
+++ b/spec/mutation-observer.spec.ts
@@ -77,6 +77,33 @@ describe("MutationObserver", () => {
     text.nodeValue = "B";
   });
 
+  it("character data changes trigger mutation event", function (done) {
+    var pal = buildPal();
+    var dom = pal.dom;
+    var document = pal.global.window.document;
+    var text = document.createTextNode("A");
+
+    var observer = dom.createMutationObserver((changes) => {
+      try {
+        expect(changes.length).toBe(1);
+        expect(changes[0].oldValue).toBe("A");
+      }
+      catch (err) {
+        fail();
+      }
+      finally {
+        observer.disconnect();
+        done();
+      }
+    });
+
+    observer.observe(text, {
+      characterData: true
+    });
+
+    text.data = "B";
+  });
+
   it("child-node changes trigger mutation event", function (done) {
     var pal = buildPal();
     var dom = pal.dom;

--- a/src/nodejs-pal-builder.ts
+++ b/src/nodejs-pal-builder.ts
@@ -73,6 +73,10 @@ function patchNotifyChange(window: Window) {
   intersectSetter(node_proto, "nodeValue", notify);
   intersectSetter(node_proto, "textContent", notify);
 
+  let char_proto = (<any>window)._core.CharacterData.prototype;
+
+  intersectSetter(char_proto, "data", notify);
+
   let element_proto = (<any>window)._core.Element.prototype;
 
   intersectMethod(element_proto, "setAttribute", notify);


### PR DESCRIPTION
Hi folks,

I ran in to [this comment](https://github.com/jsdom/jsdom/issues/639#issuecomment-259296780) by @MeirionHughes at a very opportune time today, unfortunately the polyfill didn't work for my use case (interop with RSVP, which tries to use `MutationObserver` when ran under jsdom with Jest).

It was an easy fix and so I thought I'd return the favour by upstreaming it to you guys.

Basically, you don't currently notify observers for character changes on a `TextNode`, if they are done by setting the `data` property which is inherited from `CharacterData`.