### PR TITLE
Export ensurePerformance so PLATFORM.performance can be used without initializing jsdom

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import { initializePAL, DOM, PLATFORM, FEATURE, isInitialized } from 'aurelia-pa
 import { buildPal } from './nodejs-pal-builder';
 import { MutationNotifier } from './polyfills/mutation-observer';
 
+export { ensurePerformance } from './nodejs-pal-builder';
+
 /**
 * Initializes the PAL with the NodeJS-targeted implementation.
 */

--- a/src/nodejs-pal-builder.ts
+++ b/src/nodejs-pal-builder.ts
@@ -86,8 +86,7 @@ function patchNotifyChange(window: Window) {
 }
 
 
-function ensurePerformance(window) {
-  const startOffset = Date.now ? Date.now() : + (new Date);
+export function ensurePerformance(window) {
   const _entries = [];
   const _marksIndex = {};
 


### PR DESCRIPTION
aurelia-store uses `PLATFORM.performance` to time and output performance data. When using the store in nodejs, the full `aurelia-pal-nodejs` `initialize()`, results in 6MB of JavaScript being bundled including jsdom.

This change should allow us to init `PLATFORM.performance` on nodejs without bringing in all the other dependencies. 

Related aurelia-store issue:
https://github.com/aurelia/store/issues/66